### PR TITLE
fix: return Name if OriginalName is different or empty

### DIFF
--- a/service/token.go
+++ b/service/token.go
@@ -44,7 +44,7 @@ type Token struct {
 
 // Title show string
 func (t Token) Title() string {
-	if len(t.Name) > len(t.OriginalName) {
+	if t.Name != t.OriginalName || len(t.OriginalName) == 0 {
 		return t.Name
 	}
 


### PR DESCRIPTION
It has been common to rename a token from its original name to something shorter. Unfortunately, the prior behavior always selected the longer value, which is undesirable.

This fixes the behaviors to ensure `Name` is returned when `Name` and `OriginalName` is different, or the length of the `OriginalName` is `0` (which occurs when the token has never been changed).