### PR TITLE
Add optional custom config directory $AUTHY_ROOT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ go get github.com/momaek/authy
 8. Double click `Authy.alfredworkflow` or manual import from Alfred
 9. Open Alfred and type `at {query}`
 
+### *Optional Configuration*
+By default, the authy config file (.authy.json) and cache (.authy.cache) are stored in `$HOME`.
+A custom configuration directory can be set with the environment variable `AUTHY_ROOT`
+
+e.g.
+```
+export AUTHY_ROOT=~/.dotfiles/secrets/authy
+```
+the example above would create the config file `~/.dotfiles/secrets/authy/.authy.json`
+
 #### Attention
 To use this tool, you should enable *Allow Multi-Device* in your Authy App
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ go get github.com/momaek/authy
 
 ### *Optional Configuration*
 By default, the authy config file (.authy.json) and cache (.authy.cache) are stored in `$HOME`.
-A custom configuration directory can be set with the environment variable `AUTHY_ROOT`
+A custom configuration directory can be set with the environment variable `$AUTHY_ROOT`
 
 e.g.
 ```
 export AUTHY_ROOT=~/.dotfiles/secrets/authy
 ```
 the example above would create the config file `~/.dotfiles/secrets/authy/.authy.json`
+
 
 #### Attention
 To use this tool, you should enable *Allow Multi-Device* in your Authy App

--- a/service/device.go
+++ b/service/device.go
@@ -270,11 +270,19 @@ func (d *Device) LoadExistingDeviceInfo() (devInfo DeviceRegistration, err error
 }
 
 // ConfigPath get config file path
+// Return the path to the config file
+// If the file does not exist, it will be created at $HOME ( or optionally AUTHY_ROOT )
 func (d *Device) ConfigPath(fname string) (string, error) {
 	if len(d.conf.ConfigFilePath) == 0 {
+		authy_root_path, root_dir_exists := os.LookupEnv("AUTHY_ROOT")
 		devPath, err := homedir.Dir()
-		if err != nil {
-			return "", err
+		if root_dir_exists {
+			devPath = authy_root_path 
+			d.conf.ConfigFilePath = devPath
+		} else {
+			if err != nil {
+				return "", err
+			}
 		}
 
 		d.conf.ConfigFilePath = devPath


### PR DESCRIPTION
I imagine I am not the only one who tends to obsess over keeping my '$HOME' directory clean/organized.
I have modified the ConfigPath() getter function in ./service/device.go to check for the $AUTHY_ROOT environment variable.
If this variable is present, it will be used as the directory path to store the config and cache files.
Otherwise it will resort to its default path at $HOME.