### PR TITLE
fix: On refresh save new tokens to cache

### DIFF
--- a/service/token.go
+++ b/service/token.go
@@ -143,6 +143,7 @@ func (d *Device) LoadTokenFromAuthyServer() {
 
 	d.tokenMap = tokensToMap(tks)
 	d.tokens = tks
+	d.saveToken()
 	return
 }
 


### PR DESCRIPTION
Fixes  momaek/authy#20

* LoadTokenFromAuthyServer is called by refresh which fetches new tokens but the new tokens are not saved to the cache resulting in subsequent searches failing to return new tokens unless the cache is deleted.
* Added a call to saveToken after tokens are fetched to ensure that when a refresh is called the cache is updated with the newly fetched tokens allowing subsequent searches to receive new tokens.